### PR TITLE
Add node types

### DIFF
--- a/templates/inventory_cluster_4.1.j2
+++ b/templates/inventory_cluster_4.1.j2
@@ -5,7 +5,7 @@
 {% endmacro %}
 [automationcontroller]
 {% set control_nodes = tower_control_nodes| default(0)| int %}
-{% set hybrid_nodes = tower_hyrid_nodes| default(0)| int %}
+{% set hybrid_nodes = tower_hybrid_nodes| default(0)| int %}
 {% set total_control_plane_nodes = control_nodes + hybrid_nodes %}
 {% if groups['tower']|length == total_control_plane_nodes %}
 {{ def_targets('tower', 0, control_nodes, 'control') }}

--- a/templates/inventory_cluster_4.1.j2
+++ b/templates/inventory_cluster_4.1.j2
@@ -1,8 +1,18 @@
+{% macro def_targets(target_group, target_lower_slice, target_upper_slice, target_type) %}
+{% for host in groups[target_group][target_lower_slice:target_upper_slice] %}
+{{ host }} node_type={{ target_type }}
+{% endfor %}
+{% endmacro %}
 [automationcontroller]
-{% for host in groups['tower'] %}
-{{ host }} node_type={{ control_plane_node_type | default('hybrid') }} 
-{% endfor %}{# for host in groups['tower'] #}
-
+{% set control_nodes = tower_control_nodes| default(0)| int %}
+{% set hybrid_nodes = tower_hyrid_nodes| default(0)| int %}
+{% set total_control_plane_nodes = control_nodes + hybrid_nodes %}
+{% if groups['tower']|length == total_control_plane_nodes %}
+{{ def_targets('tower', 0, control_nodes, 'control') }}
+{{ def_targets('tower', control_nodes, total_control_plane_nodes, 'hybrid') }}
+{% else %}
+{{ def_targets('tower', 0, groups['tower']|length, 'hybrid') }}
+{% endif %}
 
 [database]
 {% for host in groups['database'] %}
@@ -11,9 +21,15 @@
 
 {% if groups['execution']|default([])|length > 0 %}
 [execution_nodes]
-{% for execution_node in groups['execution'] %}
-{{ execution_node }} node_type={{ execution_plane_node_type | default('execution') }}
-{% endfor %}
+{% set execution_nodes = tower_execution_nodes| default(0)| int %}
+{% set hop_nodes = tower_hop_nodes| default(0)| int %}
+{% set total_execution_plane_nodes = execution_nodes + hop_nodes %}
+{% if execution_nodes >= 1 and groups['execution']|length == total_control_plane_nodes %}
+{{ def_targets('execution', 0, execution_nodes, 'execution') }}
+{{ def_targets('execution', execution_nodes, total_execution_plane_nodes, 'hop') }}
+{% else %}
+{{ def_targets('execution', 0, groups['execution']|length, 'execution') }}
+{% endif %}
 
 [execution_nodes:vars]
 peers=automationcontroller

--- a/templates/inventory_cluster_4.1.j2
+++ b/templates/inventory_cluster_4.1.j2
@@ -1,6 +1,6 @@
 [automationcontroller]
 {% for host in groups['tower'] %}
-{{ host }} 
+{{ host }} node_type={{ control_plane_node_type | default('hybrid') }} 
 {% endfor %}{# for host in groups['tower'] #}
 
 
@@ -12,7 +12,7 @@
 {% if groups['execution']|default([])|length > 0 %}
 [execution_nodes]
 {% for execution_node in groups['execution'] %}
-{{ execution_node }}
+{{ execution_node }} node_type={{ execution_plane_node_type | default('execution') }}
 {% endfor %}
 
 [execution_nodes:vars]

--- a/vars.yml
+++ b/vars.yml
@@ -37,6 +37,20 @@ ibmcloud_vsi_execution_profile: 'bx2-4x16'
 ibmcloud_vsi_execution_instance_count: 1
 install_execution_node: False
 
+#_NODE_VALID_TYPES = {
+#    _CONTROL_PLANE: {
+#        "types": frozenset(("control", "hybrid")),
+#        "default_type": "hybrid",
+#    },
+#    _EXECUTION_PLANE: {
+#        "types": frozenset(("execution", "hop")),
+#        "default_type": "execution",
+
+#receptor_workable_types:
+#  - control
+#  - execution
+#  - hybrid
+
 # Required ports for SSH, Tower, Exporters
 list_of_ports: [22, 80, 443, 5432, 9121, 9256, 9117, 9393, 9392, 9187, 9100, 2222]
 #ssh_public_key: 'ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC2xCcL+l/hHGI0s8qfx3sm9JV4tnTSmYzimr7t4KmYEi+RUODyKtvU+LkyedYGhdWXIMgx5yajafAoz8oacMX+SctNa9RAXz31pBC53rztKYnlvly806BXg6s0fTei1gtVt5SGhApviWGVjyQ89CkON1rM41mBqiS9015ND3D2kYBVu3g1+0t/6Tp4bSZpIdFAAf95jDtkqTMo04+c73JqQA/pyXguU7NpAmIC7YMyRXwow8Q0UTiBkcgk7Z9/HCxXz7elfx48nTko3HHgwTublODLdnOiG1BgWESLtLP5H+NvU22bUJ32nnN1WQ9RhrMHxcb8H4TsKLM257fT0I5O8an8TQ/ulhX3+pO1SFpdv6NVAgmhokIjP08VHPYknn8V5GO0q5wx11/8Gk4eT8LKrjhLJThongXxbAWKBz9pVpsnumvQH8F1i9MduJxbq980ZjRAjyNvz2RuN5RFWixCTPidpqtNi1p6uoBSyNvTZ5TzpnJhwtdxAKpL9qX6PZ8= root@localhost-localdomain'


### PR DESCRIPTION
#### Highlights of the PR
1. Add `node_type` to controlplane and execution plane nodes.
2. Added few comment lines to `vars.yaml` to describe the default and optional `node_type` to a node. 